### PR TITLE
Add check for scalar source operand validity

### DIFF
--- a/rtl/vproc_pkg.sv
+++ b/rtl/vproc_pkg.sv
@@ -298,6 +298,7 @@ typedef struct packed {
 // source register type:
 typedef struct packed {
     logic vreg;
+    logic xreg;
 `ifdef VPROC_OP_REGS_UNION
     union {
 `else


### PR DESCRIPTION
* Add check for scalar source operand validity

The problem was that Vicuna accepted instructions without checking if the corresponding scalar source registers were valid. Fixes #100.

Signed-off-by: Moritz Imfeld <moritz.imfeld@csem.ch>

* Move source_reg_valid logic from core to decoder

To avoid code duplication, the case statement in the core module has been removed. Now the case statement in the decoder is reused to decide whether a scalar source register is used for a particular instruction. To pass the signals from the decoder to the core module, I added a signal called xreg to the op_regs typedef. The vreg signal in the op_regs typedef could not be reused because it is also 0 if rs2 is not used at all or if rs2 is an immediate.

Signed-off-by: Moritz Imfeld <moritz.imfeld@csem.ch>